### PR TITLE
Limit Composer to version 1.x

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,7 @@ jobs:
       uses: shivammathur/setup-php@master
       with:
         php-version: 7.3
+        tools: composer:v1
         coverage: none
     - name: Install Reviewdog
       run: |
@@ -32,6 +33,7 @@ jobs:
       uses: shivammathur/setup-php@master
       with:
         php-version: 7.3
+        tools: composer:v1
         coverage: none
     - name: Install Reviewdog
       run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,6 +11,7 @@ jobs:
       uses: shivammathur/setup-php@master
       with:
         php-version: 7.3
+        tools: composer:v1
         # We're using phpdbg, we don't need a coverage extension.
         coverage: none
     - name: Install Dependencies
@@ -35,6 +36,7 @@ jobs:
       uses: shivammathur/setup-php@master
       with:
         php-version: 7.3
+        tools: composer:v1
         coverage: none
     - name: Install Dependencies
       run: |
@@ -72,6 +74,7 @@ jobs:
       uses: shivammathur/setup-php@master
       with:
         php-version: 7.3
+        tools: composer:v1
         coverage: none
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
Setup-php will install the latest version of Composer by default and
version 2 has just been released. Limit to version 1.x for now to
keep the continuous integration process running.