### PR TITLE
4801: Allow HEAD method for CORS

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -30,6 +30,7 @@ return [
             'PUT',
             'PATCH',
             'DELETE',
+            'HEAD'
         ],
 
         'allow_headers' => [


### PR DESCRIPTION
Checking whether a material is already on a list uses HEAD. For this
to work in a browser we need to allow this method as well in our CORS
setup.