### PR TITLE
Feature/5216 remove migration

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,10 +51,10 @@ jobs:
     name: Helm chart validation
     runs-on: ubuntu-latest
     steps:
-      - uses: azure/setup-helm@v1
-        name: Install helm
-        with:
-          version: v3.3.4
-      - name: Lint helm
-          run: helm lint infrastructure/material_list --namespace=material-list --set hpa.enabled=true --set ingress.enableTLS=true --set ingress.domain=prod.materiallist.dandigbib.org
-
+    - uses: actions/checkout@master
+    - uses: azure/setup-helm@v1
+      name: Install helm
+      with:
+        version: v3.3.4
+    - name: Lint helm
+      run: helm lint infrastructure/material_list --namespace=material-list --set hpa.enabled=true --set ingress.enableTLS=true --set ingress.domain=prod.materiallist.dandigbib.org

--- a/spec/material-list-2.0.0.yaml
+++ b/spec/material-list-2.0.0.yaml
@@ -15,8 +15,6 @@ servers:
 tags:
   - name: 'List'
     description: List handling
-  - name: 'Migrate'
-    description: Data migration
 security:
   - BearerAuth: []
 paths:


### PR DESCRIPTION
Remove last trace of the migration in the spec.

Only removes an unused tag in the spec, so a version bump seems
excessive.

Also fixes the GitHub Action workflow that's been broken for the last two years.