### PR TITLE
Cross version compatability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ trim_trailing_whitespace = false
 
 [*.{yml,yaml}]
 indent_size = 2
+
+[*.feature]
+indent_size = 2

--- a/app/Http/Controllers/v1/ListController.php
+++ b/app/Http/Controllers/v1/ListController.php
@@ -13,10 +13,24 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ListController extends Controller
 {
+    /**
+     * @var string
+     */
     protected $tableName = 'materials';
+
+    /**
+     * @var string
+     */
     protected $idColumn = 'material';
+
+    /**
+     * @var string
+     */
     protected $idFilterName = 'material_ids';
 
+    /**
+     * @return mixed[]
+     */
     public function get(Request $request, string $listId): array
     {
         $items = $this->getItems($request, $listId);
@@ -29,10 +43,15 @@ class ListController extends Controller
         ];
     }
 
+    /**
+     * @return ListItem[]
+     */
     protected function getItems(Request $request, string $listId): array
     {
+        /** @var \League\OAuth2\Client\Provider\ResourceOwnerInterface $user */
+        $user = $request->user();
         $query = DB::table($this->tableName)
-            ->where(['guid' => $request->user()->getId(), 'list' => $listId]);
+            ->where(['guid' => $user->getId(), 'list' => $listId]);
 
         // Filter to the given items, if supplied.
         $itemIds = $this->commaSeparatedQueryParamToArray($this->idFilterName, $request);
@@ -62,8 +81,10 @@ class ListController extends Controller
 
     public function hasItem(Request $request, string $listId, ListItem $item): Response
     {
+        /** @var \League\OAuth2\Client\Provider\ResourceOwnerInterface $user */
+        $user = $request->user();
         $count = $this->idQuery(DB::table($this->tableName), $item)
-            ->where(['guid' => $request->user()->getId(), 'list' => $listId])
+            ->where(['guid' => $user->getId(), 'list' => $listId])
             ->count();
 
         if ($count > 0) {
@@ -75,16 +96,18 @@ class ListController extends Controller
 
     public function addItem(Request $request, string $listId, ListItem $item): Response
     {
+        /** @var \League\OAuth2\Client\Provider\ResourceOwnerInterface $user */
+        $user = $request->user();
         $this->idQuery(DB::table($this->tableName), $item)
             ->where([
-                'guid' => $request->user()->getId(),
+                'guid' => $user->getId(),
                 'list' => $listId,
             ])
             ->delete();
 
         DB::table($this->tableName)
             ->insert([
-                'guid' => $request->user()->getId(),
+                'guid' => $user->getId(),
                 'list' => $listId,
                 $this->idColumn => urldecode($item->fullId),
                 // We need to format the date ourselves to add microseconds.
@@ -96,9 +119,11 @@ class ListController extends Controller
 
     public function removeItem(Request $request, string $listId, ListItem $item): Response
     {
+        /** @var \League\OAuth2\Client\Provider\ResourceOwnerInterface $user */
+        $user = $request->user();
         $count = $this->idQuery(DB::table($this->tableName), $item)
             ->where([
-                'guid' => $request->user()->getId(),
+                'guid' => $user->getId(),
                 'list' => $listId,
             ])
             ->delete();
@@ -109,7 +134,7 @@ class ListController extends Controller
     /**
      * Create a query that deals properly with basis/katalog items.
      */
-    protected function idQuery(Builder $query, ListItem $item, $useOr = true): Builder
+    protected function idQuery(Builder $query, ListItem $item, bool $useOr = true): Builder
     {
         $idQuery = $query->newQuery();
         // Accept matches for both materials (v1) and collections (v2).
@@ -125,12 +150,12 @@ class ListController extends Controller
         return $query->addNestedWhereQuery($idQuery, $boolean);
     }
 
+    /**
+     * @return string[]
+     */
     protected function commaSeparatedQueryParamToArray(string $param, Request $request): array
     {
-        if (!$request->has($param)) {
-            return [];
-        }
-
-        return explode(',', $request->get($param)) ?? [];
+        $param = $request->get($param);
+        return (is_string($param)) ? explode(',', $param) : [];
     }
 }

--- a/app/Http/Controllers/v2/ListController.php
+++ b/app/Http/Controllers/v2/ListController.php
@@ -8,9 +8,19 @@ use App\Http\Controllers\v1\ListController as DefaultListController;
 
 class ListController extends DefaultListController
 {
+    /**
+     * @var string
+     */
     protected $idColumn = 'collection';
+
+    /**
+     * @var string
+     */
     protected $idFilterName = 'collection_ids';
 
+    /**
+     * @return mixed[]
+     */
     public function get(Request $request, string $listId): array
     {
         $items = $this->getItems($request, $listId);

--- a/app/Http/Controllers/v2/ListController.php
+++ b/app/Http/Controllers/v2/ListController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\v2;
 
+use App\ListItem;
 use Illuminate\Http\Request;
 use App\Http\Controllers\v1\ListController as DefaultListController;
 
@@ -12,9 +13,14 @@ class ListController extends DefaultListController
 
     public function get(Request $request, string $listId): array
     {
+        $items = $this->getItems($request, $listId);
+        $collectionIds = array_map(function (ListItem  $item) {
+            return $item->collectionId();
+        }, $items);
+
         return [
             'id' => $listId,
-            'collections' => $this->getItems($request, $listId),
+            'collections' => $collectionIds,
         ];
     }
 }

--- a/app/ListItem.php
+++ b/app/ListItem.php
@@ -8,21 +8,34 @@ class ListItem
 {
     const DEFAULT_LIST_ID = 'default';
 
+    public $isCollection;
     public $agency;
     public $base;
     public $id;
     public $fullId;
 
-    public static function createFromUrlParameter(string $parameter): self
+    public static function createFromString(string $parameter): self
     {
         $itemList = new static();
 
-        if (!preg_match('/(\d+)-(\w+):(\w+)/', urldecode($parameter), $matches)) {
+        if (!preg_match('/(work-of:)?(\d+)-(\w+):(\w+)/', urldecode($parameter), $matches)) {
             throw new UnprocessableEntityHttpException('Invalid pid: ' . $parameter);
         }
 
-        [$itemList->fullId, $itemList->agency, $itemList->base, $itemList->id] = $matches;
+        [$itemList->fullId, $workOf, $itemList->agency, $itemList->base, $itemList->id] = $matches;
+        // A parameter containing the work-of: prefix identifies a collection.
+        $itemList->isCollection = (bool) $workOf;
 
         return $itemList;
+    }
+
+    public function collectionId() : string
+    {
+        return ($this->isCollection) ? $this->fullId : 'work-of:' . $this->fullId;
+    }
+
+    public function materialId() : string
+    {
+        return ($this->isCollection) ? sprintf('%s-%s:%s', $this->agency, $this->base, $this->id) : $this->fullId;
     }
 }

--- a/app/ListItem.php
+++ b/app/ListItem.php
@@ -4,14 +4,33 @@ namespace App;
 
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
-class ListItem
+final class ListItem
 {
     const DEFAULT_LIST_ID = 'default';
 
+    /**
+     * @var bool
+     */
     public $isCollection;
+
+    /**
+     * @var int
+     */
     public $agency;
+
+    /**
+     * @var string
+     */
     public $base;
+
+    /**
+     * @var string
+     */
     public $id;
+
+    /**
+     * @var string
+     */
     public $fullId;
 
     public static function createFromString(string $parameter): self

--- a/app/Providers/RouteBindingServiceProvider.php
+++ b/app/Providers/RouteBindingServiceProvider.php
@@ -24,7 +24,7 @@ class RouteBindingServiceProvider extends BaseServiceProvider
         });
 
         $binder->bind('item', function ($value): ListItem {
-            return ListItem::createFromUrlParameter($value);
+            return ListItem::createFromString($value);
         });
     }
 }

--- a/material-list.yaml
+++ b/material-list.yaml
@@ -1,1 +1,1 @@
-spec/material-list-2.0.0.yaml
+spec/material-list-2.0.1.yaml

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,6 @@ parameters:
         -
             message: '#Undefined variable: \$router#'
             path: 'routes/web.php'
+        -
+            message: '#no value type specified in iterable type Behat\\Gherkin\\Node\\TableNode#'
+            path: 'tests/*'

--- a/spec/material-list-2.0.1.yaml
+++ b/spec/material-list-2.0.1.yaml
@@ -1,0 +1,170 @@
+openapi: 3.0.0
+info:
+  version: '2.0.0'
+  title: 'Collection List'
+  license:
+    name: 'GNU General Public License v3.0'
+    url: 'https://www.gnu.org/licenses/gpl-3.0.html'
+
+servers:
+  - url: https://prod.materiallist.dandigbib.org
+    description: Production server (uses live data)
+  - url: https://test.materiallist.dandigbib.org
+    description: Test server (uses test data)
+
+tags:
+  - name: 'List'
+    description: List handling
+security:
+  - BearerAuth: []
+paths:
+  /list/{listId}:
+    get:
+      operationId: getList
+      tags:
+        - List
+      description: 'Get list with collections.'
+      parameters:
+        - $ref: '#/components/parameters/version'
+        - $ref: '#/components/parameters/listId'
+        - $ref: '#/components/parameters/collectionIds'
+      responses:
+        200:
+          description: 'The list data is returned.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/List'
+        404:
+          description: 'Unknown list.'
+        422:
+          description: 'Invalid collection id.'
+        default:
+          description: 'Unspecified error.'
+
+  /list/{listId}/{itemId}:
+    head:
+      operationId: hasItem
+      tags:
+        - List
+      description: 'Check existence of a collection on a list. To check multiple collections in one request, see the collection_ids query parameter on /list/{listId}.'
+      parameters:
+        - $ref: '#/components/parameters/version'
+        - $ref: '#/components/parameters/listId'
+        - $ref: '#/components/parameters/itemId'
+      responses:
+        200:
+          description: 'The collection exists on the list.'
+        404:
+          description: 'The list or collection does not exist.'
+        422:
+          description: 'Invalid collection id.'
+        default:
+          description: 'Unspecified error.'
+    put:
+      operationId: addItem
+      tags:
+        - List
+      description: 'Add collection to the the list.'
+      parameters:
+        - $ref: '#/components/parameters/version'
+        - $ref: '#/components/parameters/listId'
+        - $ref: '#/components/parameters/itemId'
+      responses:
+        201:
+          description: 'The collection was successfully added to the list.'
+        404:
+          description: 'Unknown list.'
+        422:
+          description: 'Invalid collection id.'
+        default:
+          description: 'Unspecified error.'
+    delete:
+      operationId: removeItem
+      tags:
+        - List
+      description: 'Delete collection from list.'
+      parameters:
+        - $ref: '#/components/parameters/version'
+        - $ref: '#/components/parameters/listId'
+        - $ref: '#/components/parameters/itemId'
+      responses:
+        204:
+          description: 'Successfully removed.'
+        404:
+          description: 'Unknown list or collection.'
+        422:
+          description: 'Invalid collection id.'
+        default:
+          description: 'Unspecified error.'
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+  parameters:
+    version:
+      name: Accept-Version
+      in: header
+      description: 'The version of the API to use.'
+      example: 2
+      schema:
+        type: integer
+        enum:
+          - 2
+      required: true
+    listId:
+      name: 'listId'
+      in: 'path'
+      description: 'The identifier of the list to return. Use "default" for the default list.'
+      required: true
+      example: 'default'
+      schema:
+        $ref: '#/components/schemas/ListId'
+    itemId:
+      name: 'itemId'
+      in: 'path'
+      description: 'The identifier of the collection.'
+      required: true
+      example: 'work-of:870970-basis:54871910'
+      schema:
+        $ref: '#/components/schemas/itemId'
+    collectionIds:
+      name: 'collection_ids'
+      in: 'query'
+      description: 'Filter the list reply down to the given collection identifiers. This is the recommended way to check for existence of multiple collections on the list.'
+      example:
+        - work-of:870970-basis:54871910
+        - work-of:870970-basis:44791668
+      explode: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/itemId'
+
+  schemas:
+    ListId:
+      description: 'List identifier. In the initial version, this can only be "default".'
+      type: string
+    itemId:
+      description: 'A collection identifier in the form "work-of:<digits>-<alphanum>:<alphanum>".'
+      type: string
+      pattern: '^work-of:\d+-\w+:\w+$'
+    List:
+      type: object
+      required:
+        - id
+        - collections
+      additionalProperties: false
+      properties:
+        id:
+          $ref: '#/components/schemas/ListId'
+        collections:
+          type: array
+          items:
+            $ref: '#/components/schemas/itemId'
+    LegacyUserId:
+      description: 'Legacy user identifier.'
+      type: string
+      example: '29A10F616FE6CA5C6E06EBF507A9FDC5BB89F8EBCF65726BEAC61C646854E83856D3B1D46BE4696EDCFB3C9F57EEBB6941D8654BC1F4B514D6217141AEA1653C'

--- a/spec/material-list-2.0.1.yaml
+++ b/spec/material-list-2.0.1.yaml
@@ -164,7 +164,3 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/itemId'
-    LegacyUserId:
-      description: 'Legacy user identifier.'
-      type: string
-      example: '29A10F616FE6CA5C6E06EBF507A9FDC5BB89F8EBCF65726BEAC61C646854E83856D3B1D46BE4696EDCFB3C9F57EEBB6941D8654BC1F4B514D6217141AEA1653C'

--- a/tests/contexts/MaterialListContext.php
+++ b/tests/contexts/MaterialListContext.php
@@ -396,32 +396,12 @@ class MaterialListContext implements Context, SnippetAcceptingContext
         $this->delete('/list/default/' . $material, [], $this->getHeaders());
     }
 
-
     /**
      * @When deleting collection :collection from the list
      */
     public function deletingCollectionFromTheList($collection)
     {
         $this->delete('/list/default/' . $collection, [], $this->getHeaders(2));
-    }
-
-    /**
-     * @Given a migrated list for legacy user id :legacyId:
-     */
-    public function aMigratedListForOuid($legacyId, TableNode $table)
-    {
-        $materials = $table->getColumn(0);
-        // Loose header.
-        array_shift($materials);
-        $this->addMaterialsToList('legacy-' . $legacyId, 'default', $materials);
-    }
-
-    /**
-     * @When the user runs migrate for legacy user id :legacyId
-     */
-    public function theUserRunsMigrateWith($legacyId)
-    {
-        $this->put('/migrate/' . $legacyId, [], $this->getHeaders());
     }
 
     /**

--- a/tests/contexts/MaterialListContext.php
+++ b/tests/contexts/MaterialListContext.php
@@ -258,9 +258,9 @@ class MaterialListContext implements Context, SnippetAcceptingContext
     }
 
     /**
-     * @Then the list should be emtpy
+     * @Then the list should be empty
      */
-    public function theListShouldBeEmtpy()
+    public function theListShouldBeEmpty()
     {
         $response = $this->checkListResponse();
 

--- a/tests/features/cross_version_compatability.feature
+++ b/tests/features/cross_version_compatability.feature
@@ -37,7 +37,7 @@ Feature: Cross version compatability
     When deleting collection "work-of:123-kat:1" from the list
     Then the system should return success
     When fetching materials in the list
-    Then the list should be emtpy
+    Then the list should be empty
 
   Scenario: Collections added in v2 can be deleted as materials in v1
     Given a known user that has no items on list
@@ -45,4 +45,4 @@ Feature: Cross version compatability
     When deleting "123-kat:1" from the list
     Then the system should return success
     When fetching collections in the list
-    Then the list should be emtpy
+    Then the list should be empty

--- a/tests/features/cross_version_compatability.feature
+++ b/tests/features/cross_version_compatability.feature
@@ -1,0 +1,48 @@
+Feature: Cross version compatability
+  Items on a list should be retrievable across versions of the API.
+
+  Scenario: Materials added in v1 are exposed as collections in v2
+    Given a known user that has no items on list
+    When material "123-kat:1" is added to the list
+    When fetching collections in the list
+    Then the system should return success
+    And the list should contain collections:
+      | collection        |
+      | work-of:123-kat:1 |
+
+  Scenario: Collections added in v2 are exposed as materials in v1
+    Given a known user that has no items on list
+    When collection "work-of:123-kat:1" is added to the list
+    When fetching materials in the list
+    Then the system should return success
+    And the list should contain:
+      | material  |
+      | 123-kat:1 |
+
+  Scenario: Materials added in v1 can be checked as collections in v2
+    Given a known user
+    When material "123-kat:1" is added to the list
+    When checking if collection "work-of:123-kat:1" is on the list
+    Then the system should return success
+
+  Scenario: Collections added in v2 can be checked as materials in v1
+    Given a known user that has no items on list
+    When collection "work-of:123-kat:1" is added to the list
+    When checking if material "123-kat:1" is on the list
+    Then the system should return success
+
+  Scenario: Materials added in v1 can be deleted as collections in v2
+    Given a known user that has no items on list
+    When material "123-kat:1" is added to the list
+    When deleting collection "work-of:123-kat:1" from the list
+    Then the system should return success
+    When fetching materials in the list
+    Then the list should be emtpy
+
+  Scenario: Collections added in v2 can be deleted as materials in v1
+    Given a known user that has no items on list
+    When collection "work-of:123-kat:1" is added to the list
+    When deleting "123-kat:1" from the list
+    Then the system should return success
+    When fetching collections in the list
+    Then the list should be emtpy

--- a/tests/features/get_list.feature
+++ b/tests/features/get_list.feature
@@ -10,7 +10,7 @@ Feature: Fetching list
     Given a known user that has no items on list
     When fetching the list
     Then the system should return success
-    And the list should be emtpy
+    And the list should be empty
 
   Scenario: User can fetch their list
     Given a known user

--- a/tests/phpunit/Unit/ListItemTest.php
+++ b/tests/phpunit/Unit/ListItemTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class ListItemTest extends TestCase
 {
-    public function testThatItCanCreateAListItemFromACorrectString()
+    public function testThatItCanCreateAListItemFromACorrectString() : void
     {
         $listItem = ListItem::createFromString('999-base:id');
         $this->assertInstanceOf(ListItem::class, $listItem);
@@ -21,7 +21,7 @@ class ListItemTest extends TestCase
         ], (array) $listItem);
     }
 
-    public function testThatListItemCreateFromUrlParameterValidatesWronglyFormattedString()
+    public function testThatListItemCreateFromUrlParameterValidatesWronglyFormattedString() : void
     {
         $urlParameter = 'john';
         $this->expectException(UnprocessableEntityHttpException::class);
@@ -29,7 +29,7 @@ class ListItemTest extends TestCase
         ListItem::createFromString($urlParameter);
     }
 
-    public function testThatItCanDetectACollectionListItem()
+    public function testThatItCanDetectACollectionListItem() : void
     {
         $listItem = ListItem::createFromString('work-of:999-base:id');
         $this->assertInstanceOf(ListItem::class, $listItem);
@@ -41,5 +41,4 @@ class ListItemTest extends TestCase
             'fullId' => 'work-of:999-base:id',
         ], (array) $listItem);
     }
-
 }

--- a/tests/phpunit/Unit/ListItemTest.php
+++ b/tests/phpunit/Unit/ListItemTest.php
@@ -8,11 +8,12 @@ use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class ListItemTest extends TestCase
 {
-    public function testThatItCanCreateAListItemFromACorrectUrlParameter()
+    public function testThatItCanCreateAListItemFromACorrectString()
     {
-        $listItem = ListItem::createFromUrlParameter('999-base:id');
+        $listItem = ListItem::createFromString('999-base:id');
         $this->assertInstanceOf(ListItem::class, $listItem);
         $this->assertSame([
+            'isCollection' => false,
             'agency' => '999',
             'base' => 'base',
             'id' => 'id',
@@ -20,11 +21,25 @@ class ListItemTest extends TestCase
         ], (array) $listItem);
     }
 
-    public function testThatListItemCreateFromUrlParameterValidatesWronglyFormattedParameter()
+    public function testThatListItemCreateFromUrlParameterValidatesWronglyFormattedString()
     {
         $urlParameter = 'john';
         $this->expectException(UnprocessableEntityHttpException::class);
         $this->expectExceptionMessage('Invalid pid: ' . $urlParameter);
-        ListItem::createFromUrlParameter($urlParameter);
+        ListItem::createFromString($urlParameter);
     }
+
+    public function testThatItCanDetectACollectionListItem()
+    {
+        $listItem = ListItem::createFromString('work-of:999-base:id');
+        $this->assertInstanceOf(ListItem::class, $listItem);
+        $this->assertSame([
+            'isCollection' => true,
+            'agency' => '999',
+            'base' => 'base',
+            'id' => 'id',
+            'fullId' => 'work-of:999-base:id',
+        ], (array) $listItem);
+    }
+
 }


### PR DESCRIPTION
This PR updates the cross-version compatibility for the service. This ensures that materials added to v1 is exposed as collections in v2 and vice versa. This also goes for checks and deletions. This is made possible because there is a partial but acceptable mapping between collections and materials based on the existence of a `work-of:` prefix for an id.

To ensure that things work as expected an new feature specification is added with examples.

To promote the fact that the service toggles between versions based on the `Accept-Version` header the OpenAPI specification is updated with the header added as a required parameter. For version 2.x it only accepts a single value: 2.

During the work I removed a few parts related to migration and legacy users that were left behind in #22 and fixed a bunch of static analysis issues that seems to have been left behind in previous PRs.