### PR TITLE
Improve handling of invalid pids

### DIFF
--- a/app/ListItem.php
+++ b/app/ListItem.php
@@ -2,8 +2,6 @@
 
 namespace App;
 
-use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
-
 final class ListItem
 {
     const DEFAULT_LIST_ID = 'default';
@@ -38,7 +36,7 @@ final class ListItem
         $itemList = new static();
 
         if (!preg_match('/(work-of:)?(\d+)-(\w+):(\w+)/', urldecode($parameter), $matches)) {
-            throw new UnprocessableEntityHttpException('Invalid pid: ' . $parameter);
+            throw new \InvalidArgumentException('Invalid pid: ' . $parameter);
         }
 
         [$itemList->fullId, $workOf, $itemList->agency, $itemList->base, $itemList->id] = $matches;

--- a/app/Providers/RouteBindingServiceProvider.php
+++ b/app/Providers/RouteBindingServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\ListItem;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use mmghv\LumenRouteBinding\RouteBindingServiceProvider as BaseServiceProvider;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class RouteBindingServiceProvider extends BaseServiceProvider
 {
@@ -24,7 +25,11 @@ class RouteBindingServiceProvider extends BaseServiceProvider
         });
 
         $binder->bind('item', function ($value): ListItem {
-            return ListItem::createFromString($value);
+            try {
+                return ListItem::createFromString($value);
+            } catch (\InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException($e->getMessage());
+            }
         });
     }
 }


### PR DESCRIPTION
If we try to return a item id contained within a list stored in the database we currently fail with a 422 Unprocessable Entity. This is not very helpful as the client cannot do anything to address this.

To address this we change the process logic to mark a problem with the list id by throwing a more general invalid argument exception. This can then be caught and handled in different situations where this might  occur:

- For situations where the item id is provided by the client we keep responding with a 422 error.
- For situations where the item id is loaded from the database we log the error and return any remaining items. 

The situation causing this issue is likely caused by a few faulty items being migrated into the database in the initial stage of the project. For v2 we have introduced stricter requirements for data formats. These are being enforced for new data but cause problems with existing data.