### PR TITLE
Reduce request memory to 11MB.

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -6,7 +6,12 @@ type: 'php:7.4'
 
 runtime:
   sizing_hints:
-    request_memory: 20
+    # A lean stack means that application memory usage is low.
+    # This allows us to have many workers which is useful as most time is spent
+    # waiting for token authorization.
+    # 10MB is the Platform.sh minimum but setting this value results in
+    # redirection errors so use a value 1 larger.
+    request_memory: 11
 
 # The build-time dependencies of the app.
 dependencies:


### PR DESCRIPTION
This is based on a sample of 10.000 requests after launching on  Platform.sh:

platform log --lines 10000 php.access | awk '{print $6}' | sort -n | uniq -c Reading log file 4yowr4fumu456-master-7rqtwti--app@ssh.fr-3.platform.sh:/var/log/php.access.log 9598 2048
 401 4096
   1 6144

We might even be able to go lower but 10MB is the minimum value on Platform.sh but setting this value leads to weird redirection errors between FPM-FPM and NGINX so go one up with 11MB.
https://docs.platform.sh/languages/php/fpm.html#2-adjust-the-maximum-number-of-php-fpm-workers