### PR TITLE
Add support for health checks

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -81,6 +81,7 @@ $app->register(\Adgangsplatformen\Support\Illuminate\AdgangsplatformenServicePro
 $app->register(Fruitcake\Cors\CorsServiceProvider::class);
 $app->register(App\Providers\RouteBindingServiceProvider::class);
 $app->register(Flipbox\LumenGenerator\LumenGeneratorServiceProvider::class);
+$app->register(\UKFast\HealthCheck\HealthCheckServiceProvider::class);
 
 /*
 |--------------------------------------------------------------------------

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "ans-group/laravel-health-check": "^1.14",
         "composer/package-versions-deprecated": "^1.11",
         "danskernesdigitalebibliotek/oauth2-adgangsplatformen": "^1.0",
         "doctrine/dbal": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,94 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df952b901311f3da7616ebdc0e623754",
+    "content-hash": "b6e84b582791ac07d329e9424040b4fe",
     "packages": [
+        {
+            "name": "ans-group/laravel-health-check",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ans-group/laravel-health-check.git",
+                "reference": "fb3bca48166703894588aa78e0631d4a4227aab2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ans-group/laravel-health-check/zipball/fb3bca48166703894588aa78e0631d4a4227aab2",
+                "reference": "fb3bca48166703894588aa78e0631d4a4227aab2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^5.4|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "illuminate/http": "^5.4|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "illuminate/support": "^5.4|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "nesbot/carbon": "^1.26.3|^2.0",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": ">=5.6.3",
+                "illuminate/database": "^5.4|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "illuminate/log": "^5.4|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "illuminate/redis": "^5.4|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^3.0|^4.0|^5.0|^6.0|^8.0",
+                "phpunit/phpunit": ">=5.0 <10"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Allows the http health check to function.",
+                "illuminate/database": "Allows the database health check to function.",
+                "illuminate/log": "Allows the log health check to function.",
+                "illuminate/redis": "Allows the redis health check to function.",
+                "league/flysystem": "Allows the ftp health check to function.",
+                "sensiolabs/security-checker": "Allows the package security health check to function."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "UKFast\\HealthCheck\\HealthCheckServiceProvider"
+                    ],
+                    "aliases": {
+                        "HealthCheck": "UKFast\\HealthCheck\\Facade\\HealthCheck"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "UKFast\\HealthCheck\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "George Kelly",
+                    "email": "george.kelly@ukfast.co.uk",
+                    "role": "Author & Maintainer"
+                },
+                {
+                    "name": "Tyler Woonton",
+                    "email": "tyler.woonton@ukfast.co.uk",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "A package for checking the health of your Laravel/Lumen applications.",
+            "keywords": [
+                "laravel",
+                "laravel-health-check",
+                "lumen",
+                "lumen-health-check",
+                "ukfast",
+                "ukfast-health-check"
+            ],
+            "support": {
+                "issues": "https://github.com/ukfast/laravel-health-check/issues",
+                "source": "https://github.com/ukfast/laravel-health-check/tree/master"
+            },
+            "time": "2023-02-20T14:47:21+00:00"
+        },
         {
             "name": "asm89/stack-cors",
             "version": "v2.0.5",
@@ -10127,5 +10213,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Use the https://github.com/ans-group/laravel-health-check package to add support for health checks. This is useful when adding external  monitoring of the application.

The package used is somewhat popular, has explicit support for Lumen and the somewhat old PHP version that we use.

The default configuration checks that we have acces to the database, a working logging system and whatever environment variables that we need. Tests show that it returns uncacheable response headers by default. 

That should be sufficient for an initial version of us.