### PR TITLE
Shift disk size from application to database

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -36,7 +36,7 @@ relationships:
   database: 'db:mysql'
 
 # The size of the persistent disk of the application (in MB).
-disk: 2048
+disk: 1024
 
 # The mounts that will be performed when the package is deployed.
 # Some of these mounts share the same path with pre-existing directories,

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -2,4 +2,4 @@
 
 db:
   type: mysql:5.7
-  disk: 2048
+  disk: 3072


### PR DESCRIPTION
We are currently at less than 20% which trigger warnings. Bump the disk size to ensure that we do not hit any limits.

The project currently has 5GB disk with 2GB used for the application and 2GB used by the database. Bump the database by 1GB and decrease the disk for the application by 1GB

Metrics show that we currently use <10MB for the application so reducing it to 1GB should be OK.